### PR TITLE
Use absolute path to bash-env-json for module

### DIFF
--- a/bash-env.nu
+++ b/bash-env.nu
@@ -16,7 +16,7 @@ export def main [
     []
   }
 
-  let raw = ($in | str join "\n") | @bash-env-json@ ...($fn_args ++ $path_args) | complete
+  let raw = ($in | str join "\n") | bash-env-json ...($fn_args ++ $path_args) | complete
   let raw_json = $raw.stdout | from json
 
   let error = $raw_json | get -i error

--- a/bash-env.nu
+++ b/bash-env.nu
@@ -16,7 +16,7 @@ export def main [
     []
   }
 
-  let raw = ($in | str join "\n") | bash-env-json ...($fn_args ++ $path_args) | complete
+  let raw = ($in | str join "\n") | @bash-env-json@ ...($fn_args ++ $path_args) | complete
   let raw_json = $raw.stdout | from json
 
   let error = $raw_json | get -i error

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,6 @@
             {
               name = "bash-env.nu-with-bash-env-json";
               src = ./bash-env.nu;
-              doCheck = true;
               dontUnpack = true;
               preferLocalBuild = true;
               allowSubstitutes = false;

--- a/flake.nix
+++ b/flake.nix
@@ -24,8 +24,7 @@
             inherit system overlays;
           };
 
-          inherit (builtins) readFile;
-          inherit (pkgs) rust-bin stdenvNoCC writeShellScriptBin;
+          inherit (pkgs) lib rust-bin stdenvNoCC writeShellScriptBin;
           flakePkgs = {
             bash-env-json = bash-env-json.packages.${system}.default;
           };


### PR DESCRIPTION
Thank you for this nice project :+1:

This PR simplifies the setup for the module.

Before this change you would need to install `bash-env-json` separately. Now you only need to load the module with

```nix
use ${bash-env-nushell.packages.${self.system}.module}/bash-env.nu
```