### PR TITLE
Fix `$in` type for nushell v0.102+

### DIFF
--- a/bash-env.nu
+++ b/bash-env.nu
@@ -16,7 +16,7 @@ export def main [
     []
   }
 
-  let input_str = if ($in | is-empty) { "" } else { $in | str join "\n" }
+  let input_str = $in | default "" | str join "\n"
   let raw = $input_str | bash-env-json ...($fn_args ++ $path_args) | complete
   let raw_json = $raw.stdout | from json
 

--- a/bash-env.nu
+++ b/bash-env.nu
@@ -16,7 +16,8 @@ export def main [
     []
   }
 
-  let raw = ($in | str join "\n") | bash-env-json ...($fn_args ++ $path_args) | complete
+  let input_str = if ($in | is-empty) { "" } else { $in | str join "\n" }
+  let raw = $input_str | bash-env-json ...($fn_args ++ $path_args) | complete
   let raw_json = $raw.stdout | from json
 
   let error = $raw_json | get -i error


### PR DESCRIPTION
This commit fixes an issue where Nushell v0.102 raises an error because `$in` is possibly undefined.

Fixes #45