### PR TITLE
fix: stop using the deprecated `--ignore-errors` flag

### DIFF
--- a/bash-env.nu
+++ b/bash-env.nu
@@ -20,7 +20,7 @@ export def main [
   let raw = $input_str | bash-env-json ...($fn_args ++ $path_args) | complete
   let raw_json = $raw.stdout | from json
 
-  let error = $raw_json | get -i error
+  let error = $raw_json | get -o error
   if $error != null {
     error make { msg: $error }
   } else if $raw.exit_code != 0 {
@@ -29,7 +29,7 @@ export def main [
 
   if ($export | is-not-empty) {
     print "warning: --export is deprecated, use --shellvars(-s) instead"
-    let exported_shellvars = ($raw_json.shellvars | select -i ...$export)
+    let exported_shellvars = ($raw_json.shellvars | select -o ...$export)
     $raw_json.env | merge ($exported_shellvars)
   } else if $shellvars or ($fn | is-not-empty) {
     $raw_json


### PR DESCRIPTION
nushell 0.106.0 deprecated the `--ignore-errors` flag in favor of a new `--optional` flag